### PR TITLE
Add missing requirements for django-phonenumber-field and mysqlclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ django-appconfig==1.0.1
 django-bootstrap-form==3.2
 django-compressor==1.5
 django-debug-toolbar==1.3.1
+django-phonenumber-field==1.1.0
+mysqlclient>=1.3.7,<1.4
 six==1.9.0


### PR DESCRIPTION
This pull request will add `django-phonenumber-field` and `mysqlclient` to requirements.txt.
